### PR TITLE
Update propagation to station 2

### DIFF
--- a/L1Trigger/L1TMuonOverlapPhase1/interface/Tools/CandidateSimMuonMatcher.h
+++ b/L1Trigger/L1TMuonOverlapPhase1/interface/Tools/CandidateSimMuonMatcher.h
@@ -132,7 +132,7 @@ public:
 
   FreeTrajectoryState simTrackToFts(const TrackingParticle& trackingParticle);
 
-  TrajectoryStateOnSurface atStation2(FreeTrajectoryState ftsStart, float eta) const;
+  TrajectoryStateOnSurface atStation2(const FreeTrajectoryState& ftsStart) const;
 
   TrajectoryStateOnSurface propagate(const SimTrack& simTrack, const edm::SimVertexContainer* simVertices);
 


### PR DESCRIPTION
Update propagation to station 2 in sim-muon matcher to check if a propagated muon is in barrer+overlap (MB2) or endcap (RE2) based on propagated z position rather than on eta in the muon production vertex.  